### PR TITLE
Scapy's automotive module

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ Libraries and tools that don't fall under the larger class of applications above
 - [Python-CAN](http://python-can.readthedocs.io/en/latest/index.html) - Python interface to various CAN implementations, including SocketCAN. Allows you to use Python 2.7.x or 3.3.x+ to communicate over CAN networks.
 - [Python-OBD](https://github.com/brendan-w/python-OBD) - A Python module for handling realtime sensor data from OBD-II vehicle ports. Works with ELM327 OBD-II adapters, and is fit for the Raspberry Pi.
 - [CanCat](https://github.com/atlas0fd00m/CanCat) - A "swiss-army knife" for interacting with live CAN data. Primary API interface in Python, but written in C++.
+- [Scapy](https://github.com/secdev/scapy) - A python library to send, receive, edit raw packets. Supports CAN and automotive protocols: see the [automotive doc](https://scapy.readthedocs.io/en/latest/layers/automotive.html)
 
 
 ### Go


### PR DESCRIPTION
Hi,
Scapy has an automotive module, and capabilities to send/receive on CAN, ISOTP... It's used for instance in this talk: https://scapy.net/conf/troopers2019 . I thought it would be cool to have.
Have a good day