### PR TITLE
Add Rinho Telematics GPS tracker with CAN Bus support

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Overview of hardware, both open source and proprietary, that you can use when co
 - [ELM327](https://www.elmelectronics.com/obdic.html) - The de facto chipset that's very cheap and can be used to connect to CAN devices.
 - [GoodThopter12](http://goodfet.sourceforge.net/hardware/goodthopter12/) - Crafted by a well-known hardware hacker, this board is a general board that can be used for exploration of automotive networks.
 - [USB2CAN](http://www.8devices.com/products/usb2can/) - Cheap USB to CAN connector that will register a device on linux that you can use to get data from a CAN network.
+- [Rinho Telematics](https://rinho.com.ar/en) - GPS trackers with native CAN Bus (J1939/FMS), WiFi fallback for offline data download, and BLE 5.0 sensors. Compatible with Traccar and Wialon.
 - [Intrepid Tools](http://store.intrepidcs.com/) - Expensive, but extremely versatile tools specifically designed for reversing CAN and other vehicle communication protocols.
 - [Red Pitaya](http://redpitaya.com/) - Replaces expensive measurement tools such as oscilloscopes, signal generators, and spectrum analyzers. Red Pitaya has LabView and Matlab interfaces, and you can write your own tools and applications for it. It even supports extensions for things like Arduino shields.
 - [ChipWhisperer](http://newae.com/tools/chipwhisperer/) - A system for side-channel attacks, such as power analysis and clock glitching.


### PR DESCRIPTION
Adding Rinho Telematics to the Hardware section.

Rinho manufactures GPS trackers with features relevant for vehicle security research:

- **Native CAN Bus**: Reads J1939/FMS without external adapters
- **OBD-II**: Direct vehicle diagnostics connection
- **WiFi Fallback**: Downloads data in areas without cellular coverage
- **BLE 5.0**: Connects temperature sensors, TPMS, iButton readers
- **Open Protocol**: Works with Traccar, Wialon, and custom platforms

Website: https://rinho.com.ar/en