### PR TITLE
Add NullSec Automotive Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,10 @@ Libraries and tools that don't fall under the larger class of applications above
 - [Scapy](https://github.com/secdev/scapy) - A python library to send, receive, edit raw packets. Supports CAN and automotive protocols: see the [automotive doc](https://scapy.readthedocs.io/en/latest/layers/automotive.html)
 - [CanoPy](https://github.com/tbruno25/canopy) - A python gui used to visualize and plot message payloads in real time.
 - [canTot](https://github.com/shipcod3/canTot) - A python-based cli framework based on sploitkit and is easy to use because it similar to working with Metasploit. This similar to an exploit framework but focused on known CAN Bus vulnerabilities or fun CAN Bus hacks.
+- [NullSec CAN Bus Tools](https://github.com/bad-antics/nullsec-canbus) - CAN bus security testing suite for vehicle penetration testing, included in NullSec Linux.
+- [NullSec CarFuzz](https://github.com/bad-antics/nullsec-carfuzz) - Automotive protocol fuzzer targeting CAN, OBD-II, and UDS interfaces.
+- [NullSec OBD-II](https://github.com/bad-antics/nullsec-obdii) - OBD-II diagnostics security testing tools.
+- [NullSec UDS](https://github.com/bad-antics/nullsec-uds) - Unified Diagnostic Services (UDS) protocol security toolkit.
 - [SocketCAN](https://python-can.readthedocs.io/en/master/interfaces/socketcan.html) Python interface to SocketCAN
 - [canmatrix](https://github.com/ebroecker/canmatrix) Python module to work with CAN matrix files
 - [canopen](https://canopen.readthedocs.io/en/latest/) Python module to communicate with CANopen devices


### PR DESCRIPTION
## Description
Adding NullSec automotive security tools to the Python Libraries and Tools section.

**NullSec Automotive Tools** - A comprehensive suite for vehicle security testing:

- **nullsec-canbus** - CAN bus security testing suite
- **nullsec-carfuzz** - Automotive protocol fuzzer (CAN, OBD-II, UDS)
- **nullsec-obdii** - OBD-II diagnostics security tools
- **nullsec-uds** - UDS protocol security toolkit

All tools are included in NullSec Linux security distribution.

Repository: https://github.com/bad-antics/nullsec-linux