### PR TITLE
Add BlackFlag ECU to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Software applications that will help you hack your car, investigate it's signals
 - [O2OO](http://web.archive.org/web/20201108091723/https://www.vanheusden.com/O2OO/) - Works with the ELM327 to record data to a SQLite database for graphing purposes. It also supports reading GPS data. You can connect this to your car and have it map out using Google Maps KML data where you drive.
 - [CANToolz](https://github.com/eik00d/CANToolz) - CANToolz is a framework for analysing CAN networks and devices. It is based on several modules which can be assembled in a pipeline.
 - [BUSMASTER](https://rbei-etas.github.io/busmaster/) -An Open Source tool to simulate, analyze and test data bus systems such as CAN, LIN, FlexRay.
+- [BlackFlag ECU](https://github.com/bad-antics/blackflag-ecu) - Professional ECU diagnostics and tuning suite with OBD-II scanning, DTC reading, live sensor monitoring, and reflash capabilities.
 - [OpenXC](http://openxcplatform.com/getting-started/index.html) - Currently, OpenXC works with `Python` and `Android`, with libraries provided to get started.
 - [openpilot](https://github.com/commaai/openpilot) - openpilot is an open source driving agent that performs the functions of Adaptive Cruise Control (ACC) and Lane Keeping Assist System (LKAS) for Hondas and Acuras.
 - [openalpr](https://github.com/openalpr/openalpr) - An open source Automatic License Plate Recognition library written in C++ with bindings in C#, Java, Node.js, Go, and Python.


### PR DESCRIPTION
Add [BlackFlag ECU](https://github.com/bad-antics/blackflag-ecu) to the Applications section.

Professional ECU diagnostics and tuning suite:
- OBD-II scanning and DTC code reading/clearing
- Live sensor data monitoring and logging
- ECU reflashing and calibration
- CAN bus analysis and replay
- 12+ stars, MIT licensed, actively maintained