### PR TITLE
Add Tesla Mod (Tesla CAN bus toolkit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Software applications that will help you hack your car, investigate it's signals
 - [mazda_getInfo](https://github.com/shipcod3/mazda_getInfo) - A PoC that the USB port is an attack surface for a Mazda car's infotainment system and how Mazda hacks are made (known bug in the CMU).
 - [talking-with-cars](https://github.com/P1kachu/talking-with-cars) - CAN related scripts, and scripts to use a car as a gamepad
 - [CANalyzat0r](https://github.com/schutzwerk/CANalyzat0r) - A security analysis toolkit for proprietary car protocols.
+- [Tesla Mod](https://github.com/hypery11/flipper-tesla-fsd) - Tesla CAN bus toolkit for Flipper Zero and ESP32. Nag killer, FSD region unlock, track mode, BMS dashboard, blind spot alert, high beam strobe, and 30+ more CAN handlers. Open source (GPL-3.0).
 
 ## Libraries and Tools
 


### PR DESCRIPTION
Adds [Tesla Mod](https://github.com/hypery11/flipper-tesla-fsd) to the Applications section. A Tesla CAN bus toolkit for Flipper Zero and ESP32 with 37 handlers. 569+ stars, GPL-3.0.