### PR TITLE
Add Jumpstarter to Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Libraries and tools that don't fall under the larger class of applications above
 - [canTot](https://github.com/shipcod3/canTot) - A python-based cli framework based on sploitkit and is easy to use because it similar to working with Metasploit. This similar to an exploit framework but focused on known CAN Bus vulnerabilities or fun CAN Bus hacks.
 - [SocketCAN](https://python-can.readthedocs.io/en/master/interfaces/socketcan.html) Python interface to SocketCAN
 - [canmatrix](https://github.com/ebroecker/canmatrix) Python module to work with CAN matrix files
+- [Jumpstarter](https://github.com/jumpstarter-dev/jumpstarter) - A hardware-in-the-loop testing framework with automotive diagnostic drivers for UDS, DoIP, and CAN bus protocols.
 - [canopen](https://canopen.readthedocs.io/en/latest/) Python module to communicate with CANopen devices
 - [cantools](https://github.com/eerimoq/cantools) Python module to decode and encode CAN messages using a DBC file
 - [Caring Caribou Next](https://github.com/Cr0wTom/caringcaribounext) - Upgraded and optimized version of the original Caring Caribou project.


### PR DESCRIPTION
Add Jumpstarter, an open source hardware-in-the-loop testing framework with automotive diagnostic drivers for UDS, DoIP, and CAN bus protocols.

https://github.com/jumpstarter-dev/jumpstarter